### PR TITLE
add shared-db-connection file for feature specs

### DIFF
--- a/spec/support/shared_db_connection.rb
+++ b/spec/support/shared_db_connection.rb
@@ -1,0 +1,8 @@
+class ActiveRecord::Base
+  mattr_accessor :shared_connection
+  @@shared_connection = nil
+  def self.connection
+    @@shared_connection || retrieve_connection
+  end
+end
+ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection


### PR DESCRIPTION
Добавил файл shared_db_connection.rb. В нем - расширение ActiveRecord::Base, которое обычно используется для feature-спеков rspec, дабы соединение с базой было постоянным (нужно для выполнения транзакций). 
Так как использую rspec для feature-тестов, то мне это необходимо. Насчет cucumber - не знаю. Но вдруг будет полезным :-)